### PR TITLE
Update sbt and plugins

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,3 @@
+version=2.2.2
+
 align=none

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1") // Code formatting
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12") // release management
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2") // artifact signing
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.6") // publishing

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1") // Code formatting
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10") // release management
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12") // release management
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2") // artifact signing
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3") // publishing
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.6") // publishing

--- a/src/main/scala/Limiter.scala
+++ b/src/main/scala/Limiter.scala
@@ -12,7 +12,6 @@ import queues.Queue
   * A purely functional, interval based rate limiter.
   */
 trait Limiter[F[_]] {
-
   /**
     * Returns an `F[Unit]` which represents the action of submitting
     * `job` to the limiter with the given priority. A higher
@@ -52,7 +51,6 @@ trait Limiter[F[_]] {
 }
 
 object Limiter {
-
   /**
     * Signals that the number of jobs waiting to be executed has
     * reached the maximum allowed number. See [[Limiter.start]]
@@ -174,5 +172,4 @@ object Limiter {
         def initial: FiniteDuration = 0.seconds
       }
     }
-
 }

--- a/src/main/scala/backpressure.scala
+++ b/src/main/scala/backpressure.scala
@@ -29,9 +29,8 @@ import scala.reflect.ClassTag
 class BackPressure[F[_], A](job: F[A]) {
   def withBackoff(
       backOff: FiniteDuration => FiniteDuration,
-      ack: BackPressure.Ack[A])(
-      implicit ev: MonadError[F, Throwable],
-      limiter: Limiter[F]): F[A] =
+      ack: BackPressure.Ack[A]
+  )(implicit ev: MonadError[F, Throwable], limiter: Limiter[F]): F[A] =
     job.attempt.flatTap { x =>
       if (ack.slowDown(x))
         limiter.interval.modify(i => backOff(i) -> i).void
@@ -40,7 +39,6 @@ class BackPressure[F[_], A](job: F[A]) {
     }.rethrow
 }
 object BackPressure {
-
   /**
     * Decides when to signal backpressure given the result or error
     * of a job
@@ -84,7 +82,7 @@ object BackPressure {
 
   trait Syntax {
     implicit def upperboundSyntaxBackPressure[F[_], A](
-        fa: F[A]): BackPressure[F, A] = new BackPressure(fa)
+        fa: F[A]
+    ): BackPressure[F, A] = new BackPressure(fa)
   }
-
 }

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,10 +1,8 @@
 package object upperbound {
-
   type LimitReachedException = Limiter.LimitReachedException
   val LimitReachedException = Limiter.LimitReachedException
 
   object syntax {
-
     /**
       * Syntactic sugar to create rates.
       *

--- a/src/test/scala/QueueSpec.scala
+++ b/src/test/scala/QueueSpec.scala
@@ -9,7 +9,6 @@ import scala.concurrent.duration._
 import queues.Queue
 
 class QueueSpec extends BaseSpec {
-
   "A Queue should" - {
     "dequeue the highest priority elements first" in forAll {
       (elems: Vector[Int]) =>

--- a/src/test/scala/SubmissionSemanticsSpec.scala
+++ b/src/test/scala/SubmissionSemanticsSpec.scala
@@ -10,9 +10,7 @@ class SubmissionSemanticsSpec extends BaseSpec {
   import DefaultEnv._
 
   "A worker" - {
-
     "when using fire-and-forget semantics should" - {
-
       "continue execution immediately" in {
         def prog =
           for {
@@ -32,7 +30,6 @@ class SubmissionSemanticsSpec extends BaseSpec {
     }
 
     "when using await semantics should" - {
-
       "complete when the result of the submitted job is ready" in {
         def prog =
           for {
@@ -77,5 +74,4 @@ class SubmissionSemanticsSpec extends BaseSpec {
       }
     }
   }
-
 }

--- a/src/test/scala/TestScenarios.scala
+++ b/src/test/scala/TestScenarios.scala
@@ -27,7 +27,8 @@ object TestScenarios {
       mean: Double,
       stdDeviation: Double,
       overshoot: Double,
-      undershoot: Double)
+      undershoot: Double
+  )
   object Metric {
     def from(samples: Vector[Long]): Metric = {
       def diffs =


### PR DESCRIPTION
- sbt 1.3.3
- sbt-release 1.0.12
- sbt-sonatype 2.6
- sbt-scalafmt 2.2.1
- scalafmt 2.2.2

Successor to #24 keeping default scalafmt settings.