### PR TITLE
A naive port to cats-effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ lazy val root = (project in file(".")).settings(
 lazy val commonSettings = Seq(
   organization := "org.systemfw",
   name := "upperbound",
-  scalaVersion := "2.12.10",
-  crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.1"),
+  scalaVersion := "2.13.6",
+  crossScalaVersions := Seq("2.12.14", scalaVersion.value),
   scalafmtOnCompile := true
 )
 
@@ -43,19 +43,14 @@ lazy val compilerOptions = {
 }
 
 lazy val typeSystemEnhancements =
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
-
-def dep(org: String)(version: String)(modules: String*) =
-  Seq(modules: _*) map { name =>
-    org %% name % version
-  }
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full)
 
 lazy val dependencies =
   libraryDependencies ++= Seq(
-    "co.fs2" %% "fs2-core" % "2.1.0",
-    "org.typelevel" %% "cats-core" % "2.0.0",
-    "org.typelevel" %% "cats-effect" % "2.0.0",
-    "org.typelevel" %% "cats-collections-core" % "0.9.0"
+    "co.fs2" %% "fs2-core" % "2.5.9",
+    "org.typelevel" %% "cats-core" % "2.6.1",
+    "org.typelevel" %% "cats-effect" % "2.5.2",
+    "org.typelevel" %% "cats-collections-core" % "0.9.3"
   )
 
 lazy val tests = {

--- a/build.sbt
+++ b/build.sbt
@@ -47,9 +47,9 @@ lazy val typeSystemEnhancements =
 
 lazy val dependencies =
   libraryDependencies ++= Seq(
-    "co.fs2" %% "fs2-core" % "2.5.9",
+    "co.fs2" %% "fs2-core" % "3.0.6",
     "org.typelevel" %% "cats-core" % "2.6.1",
-    "org.typelevel" %% "cats-effect" % "2.5.2",
+    "org.typelevel" %% "cats-effect" % "3.2.1",
     "org.typelevel" %% "cats-collections-core" % "0.9.3"
   )
 
@@ -58,7 +58,7 @@ lazy val tests = {
     "org.scalacheck" %% "scalacheck" % "1.15.4",
     "org.scalatest" %% "scalatest" % "3.2.9",
     "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0",
-    "org.typelevel" %% "cats-effect-laws" % "2.5.2"
+    "org.typelevel" %% "cats-effect-laws" % "3.2.1"
   ).map(_ % "test")
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -54,17 +54,12 @@ lazy val dependencies =
   )
 
 lazy val tests = {
-  val dependencies =
-    libraryDependencies ++= Seq(
-      "org.scalacheck" %% "scalacheck" % "1.14.2",
-      "org.scalatest" %% "scalatest" % "3.0.8",
-      "org.typelevel" %% "cats-effect-laws" % "2.0.0"
-    ).map(_ % "test")
-
-  val frameworks =
-    testFrameworks := Seq(TestFrameworks.ScalaTest)
-
-  Seq(dependencies, frameworks)
+  libraryDependencies ++= Seq(
+    "org.scalacheck" %% "scalacheck" % "1.15.4",
+    "org.scalatest" %% "scalatest" % "3.2.9",
+    "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0",
+    "org.typelevel" %% "cats-effect-laws" % "2.5.2"
+  ).map(_ % "test")
 }
 
 lazy val docs =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.5.5

--- a/src/main/scala/Limiter.scala
+++ b/src/main/scala/Limiter.scala
@@ -1,7 +1,7 @@
 package upperbound
 
 import cats._, implicits._
-import cats.effect._, concurrent._
+import cats.effect._
 import cats.effect.implicits._
 import fs2._, fs2.concurrent.SignallingRef
 
@@ -105,7 +105,7 @@ object Limiter {
     * number of jobs waiting goes below `n` again.
     * `n` defaults to `Int.MaxValue` if not specified. Must be > 0.
     */
-  def start[F[_]: Concurrent: Timer](
+  def start[F[_]: Concurrent: Temporal](
       maxRate: Rate,
       n: Int = Int.MaxValue
   ): Resource[F, Limiter[F]] = {
@@ -150,7 +150,7 @@ object Limiter {
               .interruptWhen(stop.get.attempt)
 
           executor.compile.drain.start.void
-            .as(limiter -> stop.complete(()))
+            .as(limiter -> stop.complete(()).void)
       }.flatten
     }
   }

--- a/src/test/scala/BackPressureSpec.scala
+++ b/src/test/scala/BackPressureSpec.scala
@@ -40,8 +40,7 @@ class BackPressureSpec extends BaseSpec {
         backPressure = BackPressure.Ack(_ => true)
       )
 
-      val res = mkScenario[IO](conditions).unsafeToFuture
-      env.tick(samplingWindow)
+      val res = mkScenario[IO](conditions).unsafeToFuture()
 
       res.map { r =>
         val measuredBackOff = r.jobExecutionMetrics.diffs.map(_ / T)
@@ -65,8 +64,7 @@ class BackPressureSpec extends BaseSpec {
         backPressure = BackPressure.Ack(everyOtherJob)
       )
 
-      val res = mkScenario[IO](conditions).unsafeToFuture
-      env.tick(samplingWindow)
+      val res = mkScenario[IO](conditions).unsafeToFuture()
 
       res.map { r =>
         val measuredBackOff = r.jobExecutionMetrics.diffs.map(_ / T)

--- a/src/test/scala/BaseSpec.scala
+++ b/src/test/scala/BaseSpec.scala
@@ -1,7 +1,7 @@
 package upperbound
 
 import org.scalatest._
-import cats.effect._, laws.util.TestContext
+import cats.effect._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.freespec.AsyncFreeSpec
 
@@ -11,14 +11,12 @@ abstract class BaseSpec
     with OptionValues
     with EitherValues {
   class Env {
-    val env = TestContext()
-    implicit val ctx: ContextShift[IO] = env.contextShift[IO]
-    implicit val timer: Timer[IO] = env.timer[IO]
+    import cats.effect.unsafe.IORuntime
+    implicit val global: IORuntime = IORuntime.global
   }
 
   object DefaultEnv {
-    val defaultEc = scala.concurrent.ExecutionContext.global
-    implicit val Timer: Timer[IO] = IO.timer(defaultEc)
-    implicit val ContextShift: ContextShift[IO] = IO.contextShift(defaultEc)
+    import cats.effect.unsafe.IORuntime
+    implicit val global: IORuntime = IORuntime.global
   }
 }

--- a/src/test/scala/BaseSpec.scala
+++ b/src/test/scala/BaseSpec.scala
@@ -3,6 +3,7 @@ package upperbound
 import org.scalatest._
 import cats.effect._, laws.util.TestContext
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.freespec.AsyncFreeSpec
 
 abstract class BaseSpec
     extends AsyncFreeSpec

--- a/src/test/scala/QueueSpec.scala
+++ b/src/test/scala/QueueSpec.scala
@@ -24,7 +24,7 @@ class QueueSpec extends BaseSpec {
             }
             .flatMap(_.compile.toVector)
 
-        assert(prog.unsafeRunSync === elems.reverse)
+        assert(prog.unsafeRunSync() === elems.reverse)
     }
 
     "dequeue elements with the same priority in FIFO order" in forAll {
@@ -42,7 +42,7 @@ class QueueSpec extends BaseSpec {
             }
             .flatMap(_.compile.toVector)
 
-        assert(prog.unsafeRunSync === elems)
+        assert(prog.unsafeRunSync() === elems)
     }
 
     "fail an enqueue attempt if the queue is full" in {
@@ -55,7 +55,7 @@ class QueueSpec extends BaseSpec {
           _ <- q.enqueue(1)
         } yield ()
 
-      assertThrows[LimitReachedException](prog.unsafeRunSync)
+      assertThrows[LimitReachedException](prog.unsafeRunSync())
     }
 
     "successfully enqueue after dequeueing from a full queue" in {
@@ -71,7 +71,7 @@ class QueueSpec extends BaseSpec {
           r <- q.dequeue
         } yield r
 
-      assert(prog.unsafeRunSync === 3)
+      assert(prog.unsafeRunSync() === 3)
     }
   }
 
@@ -88,8 +88,7 @@ class QueueSpec extends BaseSpec {
           prod.start >> consumer.as(true)
         }
 
-    val res = prog.unsafeToFuture
-    env.tick(3.seconds)
+    val res = prog.unsafeToFuture()
     res.map(r => assert(r))
   }
 
@@ -105,8 +104,7 @@ class QueueSpec extends BaseSpec {
         _ <- q.dequeue.timeout(1.second)
       } yield true
 
-    val res = prog.unsafeToFuture
-    env.tick(3.seconds)
+    val res = prog.unsafeToFuture()
     res.map(r => assert(r))
   }
 }

--- a/src/test/scala/QueueSpec.scala
+++ b/src/test/scala/QueueSpec.scala
@@ -2,8 +2,7 @@ package upperbound
 
 import fs2.Stream
 import cats.effect._
-import cats.syntax.all._
-import cats.instances.vector._
+import cats.syntax.flatMap._
 import scala.concurrent.duration._
 
 import queues.Queue

--- a/src/test/scala/RateLimitingSpec.scala
+++ b/src/test/scala/RateLimitingSpec.scala
@@ -9,6 +9,9 @@ class RateLimitingSpec extends BaseSpec {
   val samplingWindow = 10.seconds
   import TestScenarios._
 
+  def within(a: Long, b: Long, threshold: Long): Boolean =
+    scala.math.abs(a - b) < threshold
+
   "Limiter" - {
     "multiple fast producers, fast non-failing jobs" in {
       val E = new Env
@@ -25,11 +28,12 @@ class RateLimitingSpec extends BaseSpec {
         samplingWindow = samplingWindow
       )
 
-      val res = mkScenario[IO](conditions).unsafeToFuture
-      env.tick(samplingWindow)
+      val res = mkScenario[IO](conditions).unsafeToFuture()
 
       res.map { r =>
-        assert(r.jobExecutionMetrics.diffs.forall(_ === 200L))
+        assert(
+          r.jobExecutionMetrics.diffs.forall(within(_, 200L, 10L))
+        )
       }
     }
 
@@ -48,11 +52,12 @@ class RateLimitingSpec extends BaseSpec {
         samplingWindow = samplingWindow
       )
 
-      val res = mkScenario[IO](conditions).unsafeToFuture
-      env.tick(samplingWindow)
+      val res = mkScenario[IO](conditions).unsafeToFuture()
 
       res.map { r =>
-        assert(r.jobExecutionMetrics.diffs.forall(_ === 300L))
+        assert(
+          r.jobExecutionMetrics.diffs.forall(within(_, 300L, 10L))
+        )
       }
     }
   }

--- a/src/test/scala/SubmissionSemanticsSpec.scala
+++ b/src/test/scala/SubmissionSemanticsSpec.scala
@@ -2,7 +2,7 @@ package upperbound
 
 import syntax.rate._
 
-import cats.syntax.all._
+import cats.syntax.flatMap._
 import cats.effect._, concurrent.Ref
 import scala.concurrent.duration._
 

--- a/src/test/scala/SubmissionSemanticsSpec.scala
+++ b/src/test/scala/SubmissionSemanticsSpec.scala
@@ -3,7 +3,7 @@ package upperbound
 import syntax.rate._
 
 import cats.syntax.flatMap._
-import cats.effect._, concurrent.Ref
+import cats.effect._
 import scala.concurrent.duration._
 
 class SubmissionSemanticsSpec extends BaseSpec {
@@ -23,7 +23,7 @@ class SubmissionSemanticsSpec extends BaseSpec {
             res <- complete.get
           } yield res
 
-        val res = prog.unsafeRunSync
+        val res = prog.unsafeRunSync()
 
         assert(res === false)
       }
@@ -41,7 +41,7 @@ class SubmissionSemanticsSpec extends BaseSpec {
             state <- complete.get
           } yield res -> state
 
-        val (res, state) = prog.unsafeRunSync
+        val (res, state) = prog.unsafeRunSync()
 
         assert(res === "done")
         assert(state === true)
@@ -54,7 +54,7 @@ class SubmissionSemanticsSpec extends BaseSpec {
             Limiter.await(IO.raiseError[Int](new MyError))
         }
 
-        assertThrows[MyError](prog.unsafeRunSync)
+        assertThrows[MyError](prog.unsafeRunSync())
       }
     }
 
@@ -70,7 +70,7 @@ class SubmissionSemanticsSpec extends BaseSpec {
               task >> task >> task
             }
 
-        assertThrows[LimitReachedException](prog.unsafeRunSync)
+        assertThrows[LimitReachedException](prog.unsafeRunSync())
       }
     }
   }


### PR DESCRIPTION
Is there interest in such a basic port (I've seen in #86 that a redesign is also considered, and that the main problem may be changing the CI release setup and not the code)?

This is not using mock time, so tests run longer, but seem to pass if we inroduce thresholds into comparisons.

Any ideas for how to restore the mock time functionality would be welcome!
